### PR TITLE
Adds a stricter version of `as[T]`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -496,6 +496,25 @@ class Dataset[T] private[sql](
   }
 
   /**
+   * Returns a new Dataset where each record has been mapped on to the specified type.
+   * This only supports `U` being a class. Fields for the class will be mapped to columns of the
+   * same name (case sensitivity is determined by `spark.sql.caseSensitive`).
+   *
+   * If the schema of the Dataset does not match the desired `U` type, you can use `select`
+   * along with `alias` or `as` to rearrange or rename as required.
+   *
+   * This method eagerly projects away any columns that are not present in the specified class.
+   * It further guarantees the order of columns as well as data types to match `U`.
+   *
+   * @group basic
+   * @since 3.0.0
+   */
+  def toDS[U : Encoder]: Dataset[U] = {
+    val columns = implicitly[Encoder[U]].schema.fields.map(f => col(f.name).cast(f.dataType))
+    select(columns: _*).as[U]
+  }
+
+  /**
    * Returns the schema of this Dataset.
    *
    * @group basic


### PR DESCRIPTION
### What changes were proposed in this pull request?
Some aspects of `as[T]` are not intuitive and expected behaviour is not provided elsewhere:
* Extra columns that are not part of the type `T` are not dropped.
* Order of columns is not aligned with schema of `T`.
* Columns are not cast to the types of `T`'s fields. They have to be cast explicitly.

**This PR adds a stricter version of `as[T]` to `Dataset`.** 

### Why are the changes needed?
The behaviour of `as[T]` is not intuitive when you read code like `df.as[T].write.csv("data.csv")`. The result depends on the actual schema of `df`, where `def as[T](): Dataset[T]` should be agnostic to the schema of `df`.

A method that enforces schema of `T` on a given Dataset would be very convenient and allows to articulate and guarantee above assumptions about your data with the native Spark Dataset API. This method plays a more explicit and enforcing role than `as[T]` with respect to columns, column order and column type.

### Does this PR introduce any user-facing change?
Yes, it adds a new method to `Dataset`. It does not touch the existing `as[T]`.

Possible naming of a stricter version of `as[T]`:
* `as[T](strict = true)`
* `toDS[T]` (as in `toDF`)
* `selectAs[T]` (as this is merely selecting the columns of schema `T`)

This PR chooses the `toDS[T]` naming.

### How was this patch tested?
Existing tests for `as[T]` have been extended to assert the actual schema and emphasize the differences between `as[T]` and `toDS[T]`. Tests for `toDS[T]` are based on the `as[T]` tests.