### PR TITLE
[WIP] Reliable single-stage accumulators

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -27,8 +27,9 @@ import scala.collection.JavaConverters._
 import scala.collection.Map
 import scala.collection.mutable.HashMap
 import scala.language.implicitConversions
-import scala.reflect.{ClassTag, classTag}
+import scala.reflect.{classTag, ClassTag}
 import scala.util.control.NonFatal
+
 import com.google.common.collect.MapMaker
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
@@ -36,6 +37,7 @@ import org.apache.hadoop.io.{ArrayWritable, BooleanWritable, BytesWritable, Doub
 import org.apache.hadoop.mapred.{FileInputFormat, InputFormat, JobConf, SequenceFileInputFormat, TextInputFormat}
 import org.apache.hadoop.mapreduce.{InputFormat => NewInputFormat, Job => NewHadoopJob}
 import org.apache.hadoop.mapreduce.lib.input.{FileInputFormat => NewFileInputFormat}
+
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.deploy.{LocalSparkCluster, SparkHadoopUtil}

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -684,7 +684,8 @@ private[spark] class PythonAccumulatorV2(
     new PythonAccumulatorV2(serverHost, serverPort, secretToken)
   }
 
-  override def merge(other: AccumulatorV2[Array[Byte], JList[Array[Byte]]]): Unit = synchronized {
+  override def merge(other: AccumulatorV2[Array[Byte], JList[Array[Byte]]],
+                     fragmentId: Option[Int]): Unit = synchronized {
     val otherPythonAccumulator = other.asInstanceOf[PythonAccumulatorV2]
     // This conditional isn't strictly speaking needed - merging only currently happens on the
     // driver program - but that isn't guaranteed so incase this changes.

--- a/core/src/main/scala/org/apache/spark/executor/TaskMetrics.scala
+++ b/core/src/main/scala/org/apache/spark/executor/TaskMetrics.scala
@@ -277,7 +277,9 @@ private[spark] object TaskMetrics extends Logging {
   def empty: TaskMetrics = {
     val tm = new TaskMetrics
     tm.nameToAccums.foreach { case (name, acc) =>
-      acc.metadata = AccumulatorMetadata(AccumulatorContext.newId(), Some(name), true)
+      acc.metadata = AccumulatorMetadata(
+        AccumulatorContext.newId(), Some(name), true, AccumulatorMode.All
+      )
     }
     tm
   }

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1299,7 +1299,7 @@ private[spark] class DAGScheduler(
           case None =>
             throw new SparkException(s"attempted to access non-existent accumulator $id")
         }
-        acc.merge(updates.asInstanceOf[AccumulatorV2[Any, Any]])
+        acc.merge(updates.asInstanceOf[AccumulatorV2[Any, Any]], Some(event.task.partitionId))
         // To avoid UI cruft, ignore cases where value wasn't updated
         if (acc.name.isDefined && !updates.isZero) {
           stage.latestInfo.accumulables(id) = acc.toInfo(None, Some(acc.value))

--- a/core/src/main/scala/org/apache/spark/util/AccumulatorV2.scala
+++ b/core/src/main/scala/org/apache/spark/util/AccumulatorV2.scala
@@ -371,8 +371,12 @@ class LongAccumulator extends AccumulatorV2[jl.Long, jl.Long] {
             fragmentId
               .flatMap(_fragments.remove)
               .getOrElse((0L, 0L))
-          val maxSum = math.max(fragmentSum, o.sum)
-          val maxCount = math.max(fragmentCount, o.count)
+          val (maxSum, maxCount) =
+            if (o.sum > fragmentSum || (o.sum == fragmentSum && o.count < fragmentCount)) {
+              (o.sum, o.count)
+            } else {
+              (fragmentSum, fragmentCount)
+            }
           _sum += maxSum - fragmentSum
           _count += maxCount - fragmentCount
           fragmentId.foreach(_fragments(_) = (maxSum, maxCount))
@@ -390,7 +394,6 @@ class LongAccumulator extends AccumulatorV2[jl.Long, jl.Long] {
     case _ =>
       throw new UnsupportedOperationException(
         s"Cannot merge ${this.getClass.getName} with ${other.getClass.getName}")
-
   }
 
   private[spark] def setValue(newValue: Long): Unit = _sum = newValue
@@ -475,8 +478,12 @@ class DoubleAccumulator extends AccumulatorV2[jl.Double, jl.Double] {
             fragmentId
               .flatMap(_fragments.remove)
               .getOrElse((0.0, 0L))
-          val maxSum = math.max(fragmentSum, o.sum)
-          val maxCount = math.max(fragmentCount, o.count)
+          val (maxSum, maxCount) =
+            if (o.sum > fragmentSum || (o.sum == fragmentSum && o.count < fragmentCount)) {
+              (o.sum, o.count)
+            } else {
+              (fragmentSum, fragmentCount)
+            }
           _sum += maxSum - fragmentSum
           _count += maxCount - fragmentCount
           fragmentId.foreach(_fragments(_) = (maxSum, maxCount))

--- a/core/src/test/scala/org/apache/spark/AccumulatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/AccumulatorSuite.scala
@@ -18,19 +18,19 @@
 package org.apache.spark
 
 import java.util.concurrent.Semaphore
+
 import javax.annotation.concurrent.GuardedBy
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.ref.WeakReference
 import scala.util.control.NonFatal
-
 import org.scalatest.Matchers
 import org.scalatest.exceptions.TestFailedException
-
 import org.apache.spark.scheduler._
 import org.apache.spark.serializer.JavaSerializer
-import org.apache.spark.util.{AccumulatorContext, AccumulatorMetadata, AccumulatorV2, LongAccumulator}
+import org.apache.spark.util.AccumulatorMode.AccumulatorMode
+import org.apache.spark.util.{AccumulatorContext, AccumulatorMetadata, AccumulatorMode, AccumulatorV2, LongAccumulator}
 
 
 class AccumulatorSuite extends SparkFunSuite with Matchers with LocalSparkContext {
@@ -101,10 +101,11 @@ private[spark] object AccumulatorSuite {
       name: String,
       countFailedValues: Boolean = false,
       initValue: Long = 0,
-      id: Long = AccumulatorContext.newId()): LongAccumulator = {
+      id: Long = AccumulatorContext.newId(),
+      mode: AccumulatorMode = AccumulatorMode.All): LongAccumulator = {
     val acc = new LongAccumulator
     acc.setValue(initValue)
-    acc.metadata = AccumulatorMetadata(id, Some(name), countFailedValues)
+    acc.metadata = AccumulatorMetadata(id, Some(name), countFailedValues, mode)
     AccumulatorContext.register(acc)
     acc
   }

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -1942,7 +1942,8 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
 
   test("misbehaved accumulator should not impact other accumulators") {
     val bad = new LongAccumulator {
-      override def merge(other: AccumulatorV2[java.lang.Long, java.lang.Long]): Unit = {
+      override def merge(other: AccumulatorV2[java.lang.Long, java.lang.Long],
+                         fragmentId: Option[Int] = None): Unit = {
         throw new DAGSchedulerSuiteDummyException
       }
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/AggregatingAccumulator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/AggregatingAccumulator.scala
@@ -147,7 +147,8 @@ class AggregatingAccumulator private(
     }
   }
 
-  override def merge(other: AccumulatorV2[InternalRow, InternalRow]): Unit = withSQLConf(()) {
+  override def merge(other: AccumulatorV2[InternalRow, InternalRow],
+                     fragmentId: Option[Int] = None): Unit = withSQLConf(()) {
     if (!other.isZero) {
       other match {
         case agg: AggregatingAccumulator =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/debug/package.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/debug/package.scala
@@ -208,7 +208,8 @@ package object debug {
       }
       override def reset(): Unit = _set.clear()
       override def add(v: T): Unit = _set.add(v)
-      override def merge(other: AccumulatorV2[T, java.util.Set[T]]): Unit = {
+      override def merge(other: AccumulatorV2[T, java.util.Set[T]],
+                         fragmentId: Option[Int] = None): Unit = {
         _set.addAll(other.value)
       }
       override def value: java.util.Set[T] = _set

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
@@ -49,7 +49,8 @@ class SQLMetric(val metricType: String, initValue: Long = 0L) extends Accumulato
 
   override def reset(): Unit = _value = _zeroValue
 
-  override def merge(other: AccumulatorV2[Long, Long]): Unit = other match {
+  override def merge(other: AccumulatorV2[Long, Long],
+                     fragmentId: Option[Int] = None): Unit = other match {
     case o: SQLMetric => _value += o.value
     case _ => throw new UnsupportedOperationException(
       s"Cannot merge ${this.getClass.getName} with ${other.getClass.getName}")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/EventTimeWatermarkExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/EventTimeWatermarkExec.scala
@@ -74,7 +74,8 @@ class EventTimeStatsAccum(protected var currentStats: EventTimeStats = EventTime
     currentStats.add(v)
   }
 
-  override def merge(other: AccumulatorV2[Long, EventTimeStats]): Unit = {
+  override def merge(other: AccumulatorV2[Long, EventTimeStats],
+                     fragmentId: Option[Int] = None): Unit = {
     currentStats.merge(other.value)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -1525,7 +1525,8 @@ class NumRowGroupsAcc extends AccumulatorV2[Integer, Integer] {
 
   override def add(v: Integer): Unit = _sum += v
 
-  override def merge(other: AccumulatorV2[Integer, Integer]): Unit = other match {
+  override def merge(other: AccumulatorV2[Integer, Integer],
+                     fragmentId: Option[Int] = None): Unit = other match {
     case a: NumRowGroupsAcc => _sum += a._sum
     case _ => throw new UnsupportedOperationException(
       s"Cannot merge ${this.getClass.getName} with ${other.getClass.getName}")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/MetricsAggregationBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/MetricsAggregationBenchmark.scala
@@ -22,7 +22,6 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.mutable
 import scala.concurrent.duration._
-
 import org.apache.spark.{SparkConf, TaskState}
 import org.apache.spark.benchmark.{Benchmark, BenchmarkBase}
 import org.apache.spark.executor.ExecutorMetrics
@@ -31,7 +30,7 @@ import org.apache.spark.scheduler._
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.metric.SQLMetricInfo
 import org.apache.spark.status.ElementTrackingStore
-import org.apache.spark.util.{AccumulatorMetadata, LongAccumulator, Utils}
+import org.apache.spark.util.{AccumulatorMetadata, AccumulatorMode, LongAccumulator, Utils}
 import org.apache.spark.util.kvstore.InMemoryStore
 
 /**
@@ -116,7 +115,7 @@ object MetricsAggregationBenchmark extends BenchmarkBase {
 
         val accumulables = (0 until numMetrics).map { mid =>
           val acc = new LongAccumulator
-          acc.metadata = AccumulatorMetadata(mid, None, false)
+          acc.metadata = AccumulatorMetadata(mid, None, false, AccumulatorMode.All)
           acc.toInfo(Some(i.toLong), None)
         }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/MetricsAggregationBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/MetricsAggregationBenchmark.scala
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.mutable
 import scala.concurrent.duration._
+
 import org.apache.spark.{SparkConf, TaskState}
 import org.apache.spark.benchmark.{Benchmark, BenchmarkBase}
 import org.apache.spark.executor.ExecutorMetrics

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
@@ -20,10 +20,8 @@ package org.apache.spark.sql.execution.ui
 import java.util.Properties
 
 import scala.collection.mutable.ListBuffer
-
 import org.json4s.jackson.JsonMethods._
 import org.scalatest.BeforeAndAfter
-
 import org.apache.spark._
 import org.apache.spark.LocalSparkContext._
 import org.apache.spark.executor.ExecutorMetrics
@@ -36,13 +34,13 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
 import org.apache.spark.sql.catalyst.util.quietly
-import org.apache.spark.sql.execution.{LeafExecNode, QueryExecution, SparkPlanInfo, SQLExecution}
+import org.apache.spark.sql.execution.{LeafExecNode, QueryExecution, SQLExecution, SparkPlanInfo}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.functions.count
 import org.apache.spark.sql.internal.StaticSQLConf.UI_RETAINED_EXECUTIONS
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.status.ElementTrackingStore
-import org.apache.spark.util.{AccumulatorMetadata, JsonProtocol, LongAccumulator}
+import org.apache.spark.util.{AccumulatorMetadata, AccumulatorMode, JsonProtocol, LongAccumulator}
 import org.apache.spark.util.kvstore.InMemoryStore
 
 
@@ -110,7 +108,7 @@ class SQLAppStatusListenerSuite extends SharedSparkSession with JsonTestUtils
   private def createAccumulatorInfos(accumulatorUpdates: Map[Long, Long]): Seq[AccumulableInfo] = {
     accumulatorUpdates.map { case (id, value) =>
       val acc = new LongAccumulator
-      acc.metadata = AccumulatorMetadata(id, None, false)
+      acc.metadata = AccumulatorMetadata(id, None, false, AccumulatorMode.All)
       acc.toInfo(Some(value), None)
     }.toSeq
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
@@ -20,8 +20,10 @@ package org.apache.spark.sql.execution.ui
 import java.util.Properties
 
 import scala.collection.mutable.ListBuffer
+
 import org.json4s.jackson.JsonMethods._
 import org.scalatest.BeforeAndAfter
+
 import org.apache.spark._
 import org.apache.spark.LocalSparkContext._
 import org.apache.spark.executor.ExecutorMetrics
@@ -34,7 +36,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
 import org.apache.spark.sql.catalyst.util.quietly
-import org.apache.spark.sql.execution.{LeafExecNode, QueryExecution, SQLExecution, SparkPlanInfo}
+import org.apache.spark.sql.execution.{LeafExecNode, QueryExecution, SparkPlanInfo, SQLExecution}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.functions.count
 import org.apache.spark.sql.internal.StaticSQLConf.UI_RETAINED_EXECUTIONS


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR introduces the notion of an accumulator mode which allows to select how accumulators behave when they merge accumulator values from partitions.

The current behaviour is to merge in `ALL` value from partitions. When partitions are executed multiple times (e.g. re-run on failure or cache eviction, rerunning actions, usage of a stage in multiple actions), accumulators count all increments and cannot be used to count while ignoring re-computations of partitions. The added `ALL` mode is the default mode.

The `MAX` mode keeps the most-comprehensive accumulator value for each partition. In case of a `LongAccumulator`, this reflects the largest seen value. A `LongAccumulator` that counts the number of rows or nulls in a dataset provides accurate results in this mode.

The `LAST` mode keeps the latest accumulator per partition only. This provides the latest value of the accumulator.

The accumulator on the driver uses additional memory in the order of the number of partitions.

### Why are the changes needed?
With the current behaviour, only a very limited class of accumulator use cases can be implemented, those that count across partition executions. Counting read and written bytes is a good example where this behaviour is desired. Counting the number of rows of the dataset, or rows that meet a certain condition cannot be implemented with this behaviour. The accumulator over-counts and thus only provides a pessimistic upper bound of the true value.

### Does this PR introduce any user-facing change?
Yes, it introduces an `AccumulatorMode` enum that can be used when accumulators get registered to pick the merge behaviour.

### How was this patch tested?
Unit tests in the `AccumulatorSuite`.