### PR TITLE
Add flatMapSortedGroups to KeyValueGroupedDataset

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/object.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/object.scala
@@ -395,8 +395,8 @@ object MapGroups {
       UnresolvedDeserializer(encoderFor[K].deserializer, groupingAttributes),
       UnresolvedDeserializer(encoderFor[T].deserializer, dataAttributes),
       groupingAttributes,
-      None,
       dataAttributes,
+      None,
       CatalystSerde.generateObjAttr[U],
       child)
     CatalystSerde.serialize[U](mapped)
@@ -405,16 +405,16 @@ object MapGroups {
   def apply[K : Encoder, T : Encoder, U : Encoder](
     func: (K, Iterator[T]) => TraversableOnce[U],
     groupingAttributes: Seq[Attribute],
-    sortAttributes: Seq[Attribute],
     dataAttributes: Seq[Attribute],
+    dataOrder: Seq[SortOrder],
     child: LogicalPlan): LogicalPlan = {
     val mapped = new MapGroups(
       func.asInstanceOf[(Any, Iterator[Any]) => TraversableOnce[Any]],
       UnresolvedDeserializer(encoderFor[K].deserializer, groupingAttributes),
       UnresolvedDeserializer(encoderFor[T].deserializer, dataAttributes),
       groupingAttributes,
-      Some(sortAttributes),
       dataAttributes,
+      Some(dataOrder),
       CatalystSerde.generateObjAttr[U],
       child)
     CatalystSerde.serialize[U](mapped)
@@ -424,8 +424,8 @@ object MapGroups {
 /**
  * Applies func to each unique group in `child`, based on the evaluation of `groupingAttributes`.
  * Func is invoked with an object representation of the grouping key an iterator containing the
- * object representation of all the rows with that key. Given an optional `sortAttributes` data
- * in the iterator will be sorted accordingly. That sorting does not add computational complexity.
+ * object representation of all the rows with that key. Given an optional `dataOrder`, data in
+ * the iterator will be sorted accordingly. That sorting does not add computational complexity.
  *
  * @param keyDeserializer used to extract the key object for each group.
  * @param valueDeserializer used to extract the items in the iterator from an input row.
@@ -435,8 +435,8 @@ case class MapGroups(
     keyDeserializer: Expression,
     valueDeserializer: Expression,
     groupingAttributes: Seq[Attribute],
-    sortAttributes: Option[Seq[Attribute]],
     dataAttributes: Seq[Attribute],
+    dataOrder: Option[Seq[SortOrder]],
     outputObjAttr: Attribute,
     child: LogicalPlan) extends UnaryNode with ObjectProducer {
   override protected def withNewChildInternal(newChild: LogicalPlan): MapGroups =

--- a/sql/core/src/main/scala/org/apache/spark/sql/KeyValueGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/KeyValueGroupedDataset.scala
@@ -174,9 +174,9 @@ class KeyValueGroupedDataset[K, V] private[sql](
   /**
    * (Scala-specific)
    * Applies the given function to each group of data.  For each unique group, the function will
-   * be passed the group key and an iterator that contains all of the elements in the group. The
-   * function can return an iterator containing elements of an arbitrary type which will be returned
-   * as a new [[Dataset]].
+   * be passed the group key and a sorted iterator that contains all of the elements in the group.
+   * The function can return an iterator containing elements of an arbitrary type which will be
+   * returned as a new [[Dataset]].
    *
    * This function does not support partial aggregation, and as a result requires shuffling all
    * the data in the [[Dataset]]. If an application intends to perform an aggregation over each
@@ -207,6 +207,26 @@ class KeyValueGroupedDataset[K, V] private[sql](
     )
   }
 
+
+  /**
+   * (Scala-specific)
+   * Applies the given function to each group of data.  For each unique group, the function will
+   * be passed the group key and a sorted iterator that contains all of the elements in the group.
+   * The function can return an iterator containing elements of an arbitrary type which will be
+   * returned as a new [[Dataset]].
+   *
+   * This function does not support partial aggregation, and as a result requires shuffling all
+   * the data in the [[Dataset]]. If an application intends to perform an aggregation over each
+   * key, it is best to use the reduce function or an
+   * `org.apache.spark.sql.expressions#Aggregator`.
+   *
+   * Internally, the implementation will spill to disk if any given group is too large to fit into
+   * memory.  However, users must take care to avoid materializing the whole iterator for a group
+   * (for example, by calling `toList`) unless they are sure that this is possible given the memory
+   * constraints of their cluster.
+   *
+   * @since 3.3.0
+   */
   def flatMapSortedGroups[U : Encoder]
       (sortExpr: Column, sortExprs: Column*)
       (f: (K, Iterator[V]) => TraversableOnce[U]): Dataset[U] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -772,9 +772,9 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         execution.AppendColumnsExec(f, in, out, planLater(child)) :: Nil
       case logical.AppendColumnsWithObject(f, childSer, newSer, child) =>
         execution.AppendColumnsWithObjectExec(f, childSer, newSer, planLater(child)) :: Nil
-      case logical.MapGroups(f, key, value, grouping, sort, data, objAttr, child) =>
+      case logical.MapGroups(f, key, value, grouping, data, order, objAttr, child) =>
         execution.MapGroupsExec(
-          f, key, value, grouping, sort, data, objAttr, planLater(child)
+          f, key, value, grouping, data, order, objAttr, planLater(child)
         ) :: Nil
       case logical.FlatMapGroupsWithState(
           f, keyDeserializer, valueDeserializer, grouping, data, output, stateEncoder, outputMode,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -772,8 +772,10 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         execution.AppendColumnsExec(f, in, out, planLater(child)) :: Nil
       case logical.AppendColumnsWithObject(f, childSer, newSer, child) =>
         execution.AppendColumnsWithObjectExec(f, childSer, newSer, planLater(child)) :: Nil
-      case logical.MapGroups(f, key, value, grouping, data, objAttr, child) =>
-        execution.MapGroupsExec(f, key, value, grouping, data, objAttr, planLater(child)) :: Nil
+      case logical.MapGroups(f, key, value, grouping, sort, data, objAttr, child) =>
+        execution.MapGroupsExec(
+          f, key, value, grouping, sort, data, objAttr, planLater(child)
+        ) :: Nil
       case logical.FlatMapGroupsWithState(
           f, keyDeserializer, valueDeserializer, grouping, data, output, stateEncoder, outputMode,
           isFlatMapGroupsWithState, timeout, hasInitialState, initialStateGroupAttrs,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FlatMapGroupsWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FlatMapGroupsWithStateExec.scala
@@ -469,7 +469,7 @@ object FlatMapGroupsWithStateExec {
     } else {
       MapGroupsExec(
         userFunc, keyDeserializer, valueDeserializer, groupingAttributes,
-        None, dataAttributes, outputObjAttr, timeoutConf, child)
+        dataAttributes, None, outputObjAttr, timeoutConf, child)
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FlatMapGroupsWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FlatMapGroupsWithStateExec.scala
@@ -469,7 +469,7 @@ object FlatMapGroupsWithStateExec {
     } else {
       MapGroupsExec(
         userFunc, keyDeserializer, valueDeserializer, groupingAttributes,
-        dataAttributes, outputObjAttr, timeoutConf, child)
+        None, dataAttributes, outputObjAttr, timeoutConf, child)
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -555,38 +555,33 @@ class DatasetSuite extends QueryTest
 
   test("groupBy function, flatMapSorted by func") {
     val ds = Seq(("a", 1, 10), ("a", 2, 20), ("b", 2, 1), ("b", 1, 2), ("c", 1, 1)).toDS()
-    ds.sort($"id".desc)
     val grouped = ds.groupByKey(v => (v._1, "word"))
     val aggregated = grouped.flatMapSortedGroups(v => v._2) { (g, iter) =>
-      Iterator(
-        g._1,
-        iter.mkString(", ")
-      )
+      Iterator(g._1, iter.mkString(", "))
     }
 
     checkDatasetUnorderly(
       aggregated,
       "a", "(a,1,10), (a,2,20)",
       "b", "(b,1,2), (b,2,1)",
-      "c", "(c,1,1)")
+      "c", "(c,1,1)"
+    )
   }
 
   test("groupBy function, flatMapSorted by expr") {
     val ds = Seq(("a", 1, 10), ("a", 2, 20), ("b", 2, 1), ("b", 1, 2), ("c", 1, 1))
       .toDF("key", "seq", "value")
     val grouped = ds.groupByKey(v => (v.getString(0), "word"))
-    val aggregated = grouped.flatMapSortedGroups($"seq") { (g, iter) =>
-      Iterator(
-        g._1,
-        iter.mkString(", ")
-      )
+    val aggregated = grouped.flatMapSortedGroups($"seq", expr("length(key)")) { (g, iter) =>
+      Iterator(g._1, iter.mkString(", "))
     }
 
     checkDatasetUnorderly(
       aggregated,
-      "a", "(a,1,10), (a,2,20)",
-      "b", "(b,1,2), (b,2,1)",
-      "c", "(c,1,1)")
+      "a", "[a,1,10], [a,2,20]",
+      "b", "[b,1,2], [b,2,1]",
+      "c", "[c,1,1]"
+    )
   }
 
   test("groupBy function, mapValues, flatMap") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -553,6 +553,23 @@ class DatasetSuite extends QueryTest
       "a", "30", "b", "3", "c", "1")
   }
 
+  test("groupBy function, flatMapSorted") {
+    val ds = Seq(("a", 1, 10), ("a", 2, 20), ("b", 2, 1), ("b", 1, 2), ("c", 1, 1)).toDS()
+    val grouped = ds.groupByKey(v => (v._1, "word"))
+    val aggregated = grouped.flatMapSortedGroups(v => v._2) { (g, iter) =>
+      Iterator(
+        g._1,
+        iter.mkString(", ")
+      )
+    }
+
+    checkDatasetUnorderly(
+      aggregated,
+      "a", "(a,1,10), (a,2,20)",
+      "b", "(b,1,2), (b,2,1)",
+      "c", "(c,1,1)")
+  }
+
   test("groupBy function, mapValues, flatMap") {
     val ds = Seq(("a", 10), ("a", 20), ("b", 1), ("b", 2), ("c", 1)).toDS()
     val keyValue = ds.groupByKey(_._1).mapValues(_._2)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This adds a sorted version of `ds.groupByKey(…).flatMapGroups(…)`.

### Why are the changes needed?
The existing method `flatMapGroups` provides an iterator of rows for each group key. If user code would requires those rows in a particular order, that iterator would have to be sorted first, which is against the idea of an iterator in the first place. For groups that do not fit into memory of one executor, this approach does not work.

[org.apache.spark.sql.KeyValueGroupedDataset](https://github.com/apache/spark/blob/47485a3c2df3201c838b939e82d5b26332e2d858/sql/core/src/main/scala/org/apache/spark/sql/KeyValueGroupedDataset.scala#L134-L137):
> Internally, the implementation will spill to disk if any given group is too large to fit into
> memory.  However, users must take care to avoid materializing the whole iterator for a group
> (for example, by calling `toList`) unless they are sure that this is possible given the memory
> constraints of their cluster.

The implementation of `KeyValueGroupedDataset.flatMapGroups` already sorts each partition according to the group key. By additionally sorting by some data columns, the iterator can be guaranteed to provide some order.

### Does this PR introduce _any_ user-facing change?
This adds `KeyValueGroupedDataset.flatMapSortedGroups`.

### How was this patch tested?
There is test `DatasetSuite."groupBy function, flatMapSorted by func"` and `DatasetSuite."groupBy function, flatMapSorted by expr"`.