### PR TITLE
[SPARK-38833][PYTHON][SQL] Allow applyInPandas to return empty DataFrame without columns

### DIFF
--- a/python/pyspark/sql/tests/test_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/test_pandas_grouped_map.py
@@ -51,6 +51,7 @@ from pyspark.sql.types import (
     NullType,
     TimestampType,
 )
+from pyspark.sql.utils import PythonException
 from pyspark.testing.sqlutils import (
     ReusedSQLTestCase,
     have_pandas,
@@ -267,6 +268,72 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
         expected = expected.sort_values(["id", "v"]).reset_index(drop=True)
         expected = expected.assign(norm=expected.norm.astype("float64"))
         assert_frame_equal(expected, result)
+
+    def test_groupby_not_returning_pandas_dataframe(self):
+        df = self.data
+
+        def stats(key, pdf):
+            return key
+
+        with QuietTest(self.sc):
+            with self.assertRaisesRegex(PythonException, "Return type of the user-defined function should be "
+                                                         "pandas.DataFrame, but is <class 'tuple'>"):
+                df.groupby("id").applyInPandas(stats, schema="id integer, m double").collect()
+
+    def test_groupby_returning_different_number_of_columns(self):
+        df = self.data
+
+        def stats(key, pdf):
+            v = pdf.v
+            # returning three columns
+            res = pd.DataFrame([key + (v.mean(), v.std())])
+            return res
+
+        with QuietTest(self.sc):
+            with self.assertRaisesRegex(PythonException, "Number of columns of the returned pandas.DataFrame "
+                                                         "doesn't match specified schema. Expected: 2 Actual: 3"):
+                # stats returns three columns while here we set schema with two columns
+                df.groupby("id").applyInPandas(stats, schema="id integer, m double").collect()
+
+    def test_groupby_returning_empty_dataframe(self):
+        df = self.data
+
+        def odd_means(key, pdf):
+            if key[0] % 2 == 0:
+                return pd.DataFrame([])
+            else:
+                return pd.DataFrame([key + (pdf.v.mean(),)])
+
+        expected_ids = {row[0] for row in self.data.collect() if row[0] % 2 != 0}
+
+        result = (
+            df.groupby("id")
+            .applyInPandas(odd_means, schema="id integer, m double")
+            .sort("id", "m")
+            .collect()
+        )
+
+        actual_ids = {row[0] for row in result}
+        self.assertSetEqual(expected_ids, actual_ids)
+
+        self.assertEqual(len(expected_ids), len(result))
+        for row in result:
+            self.assertEqual(24.5, row[1])
+
+    def test_groupby_returning_empty_dataframe_and_different_number_of_columns(self):
+        df = self.data
+
+        def odd_means(key, pdf):
+            if key[0] % 2 == 0:
+                return pd.DataFrame([], columns=['id'])
+            else:
+                return pd.DataFrame([key + (pdf.v.mean(),)])
+
+        with QuietTest(self.sc):
+            with self.assertRaisesRegex(PythonException, "Number of columns of the returned pandas.DataFrame "
+                                                         "doesn't match specified schema. Expected: 2 Actual: 1"):
+                # stats returns one columns for even keys while here we set schema with two columns
+                df.groupby("id").applyInPandas(odd_means, schema="id integer, m double").collect()
 
     def test_datatype_string(self):
         df = self.data

--- a/python/pyspark/sql/tests/test_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/test_pandas_grouped_map.py
@@ -277,9 +277,10 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
 
         with QuietTest(self.sc):
             with self.assertRaisesRegex(
-                    PythonException,
-                    "Return type of the user-defined function should be pandas.DataFrame, "
-                    "but is <class 'tuple'>"):
+                PythonException,
+                "Return type of the user-defined function should be pandas.DataFrame, "
+                "but is <class 'tuple'>",
+            ):
                 df.groupby("id").applyInPandas(stats, schema="id integer, m double").collect()
 
     def test_groupby_returning_different_number_of_columns(self):
@@ -293,9 +294,10 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
 
         with QuietTest(self.sc):
             with self.assertRaisesRegex(
-                    PythonException,
-                    "Number of columns of the returned pandas.DataFrame doesn't match "
-                    "specified schema. Expected: 2 Actual: 3"):
+                PythonException,
+                "Number of columns of the returned pandas.DataFrame doesn't match "
+                "specified schema. Expected: 2 Actual: 3",
+            ):
                 # stats returns three columns while here we set schema with two columns
                 df.groupby("id").applyInPandas(stats, schema="id integer, m double").collect()
 
@@ -329,15 +331,16 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
 
         def odd_means(key, pdf):
             if key[0] % 2 == 0:
-                return pd.DataFrame([], columns=['id'])
+                return pd.DataFrame([], columns=["id"])
             else:
                 return pd.DataFrame([key + (pdf.v.mean(),)])
 
         with QuietTest(self.sc):
             with self.assertRaisesRegex(
-                    PythonException,
-                    "Number of columns of the returned pandas.DataFrame doesn't match "
-                    "specified schema. Expected: 2 Actual: 1"):
+                PythonException,
+                "Number of columns of the returned pandas.DataFrame doesn't match "
+                "specified schema. Expected: 2 Actual: 1",
+            ):
                 # stats returns one columns for even keys while here we set schema with two columns
                 df.groupby("id").applyInPandas(odd_means, schema="id integer, m double").collect()
 

--- a/python/pyspark/sql/tests/test_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/test_pandas_grouped_map.py
@@ -276,8 +276,10 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
             return key
 
         with QuietTest(self.sc):
-            with self.assertRaisesRegex(PythonException, "Return type of the user-defined function should be "
-                                                         "pandas.DataFrame, but is <class 'tuple'>"):
+            with self.assertRaisesRegex(
+                    PythonException,
+                    "Return type of the user-defined function should be pandas.DataFrame, "
+                    "but is <class 'tuple'>"):
                 df.groupby("id").applyInPandas(stats, schema="id integer, m double").collect()
 
     def test_groupby_returning_different_number_of_columns(self):
@@ -290,8 +292,10 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
             return res
 
         with QuietTest(self.sc):
-            with self.assertRaisesRegex(PythonException, "Number of columns of the returned pandas.DataFrame "
-                                                         "doesn't match specified schema. Expected: 2 Actual: 3"):
+            with self.assertRaisesRegex(
+                    PythonException,
+                    "Number of columns of the returned pandas.DataFrame doesn't match "
+                    "specified schema. Expected: 2 Actual: 3"):
                 # stats returns three columns while here we set schema with two columns
                 df.groupby("id").applyInPandas(stats, schema="id integer, m double").collect()
 
@@ -330,8 +334,10 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
                 return pd.DataFrame([key + (pdf.v.mean(),)])
 
         with QuietTest(self.sc):
-            with self.assertRaisesRegex(PythonException, "Number of columns of the returned pandas.DataFrame "
-                                                         "doesn't match specified schema. Expected: 2 Actual: 1"):
+            with self.assertRaisesRegex(
+                    PythonException,
+                    "Number of columns of the returned pandas.DataFrame doesn't match "
+                    "specified schema. Expected: 2 Actual: 1"):
                 # stats returns one columns for even keys while here we set schema with two columns
                 df.groupby("id").applyInPandas(odd_means, schema="id integer, m double").collect()
 

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -162,7 +162,9 @@ def wrap_cogrouped_map_pandas_udf(f, return_type, argspec):
                 "Return type of the user-defined function should be "
                 "pandas.DataFrame, but is {}".format(type(result))
             )
-        if not len(result.columns) == len(return_type):
+        # the number of columns of result have to match the return type
+        # but it is fine for result to have no columns at all if it is empty
+        if not (len(result.columns) == len(return_type) or len(result.columns) == 0 and result.empty):
             raise RuntimeError(
                 "Number of columns of the returned pandas.DataFrame "
                 "doesn't match specified schema. "
@@ -188,7 +190,9 @@ def wrap_grouped_map_pandas_udf(f, return_type, argspec):
                 "Return type of the user-defined function should be "
                 "pandas.DataFrame, but is {}".format(type(result))
             )
-        if not len(result.columns) == len(return_type):
+        # the number of columns of result have to match the return type
+        # but it is fine for result to have no columns at all if it is empty
+        if not (len(result.columns) == len(return_type) or len(result.columns) == 0 and result.empty):
             raise RuntimeError(
                 "Number of columns of the returned pandas.DataFrame "
                 "doesn't match specified schema. "

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -164,7 +164,8 @@ def wrap_cogrouped_map_pandas_udf(f, return_type, argspec):
             )
         # the number of columns of result have to match the return type
         # but it is fine for result to have no columns at all if it is empty
-        if not (len(result.columns) == len(return_type) or len(result.columns) == 0 and result.empty):
+        if not (len(result.columns) == len(return_type) or
+                len(result.columns) == 0 and result.empty):
             raise RuntimeError(
                 "Number of columns of the returned pandas.DataFrame "
                 "doesn't match specified schema. "
@@ -192,7 +193,8 @@ def wrap_grouped_map_pandas_udf(f, return_type, argspec):
             )
         # the number of columns of result have to match the return type
         # but it is fine for result to have no columns at all if it is empty
-        if not (len(result.columns) == len(return_type) or len(result.columns) == 0 and result.empty):
+        if not (len(result.columns) == len(return_type) or
+                len(result.columns) == 0 and result.empty):
             raise RuntimeError(
                 "Number of columns of the returned pandas.DataFrame "
                 "doesn't match specified schema. "

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -164,8 +164,9 @@ def wrap_cogrouped_map_pandas_udf(f, return_type, argspec):
             )
         # the number of columns of result have to match the return type
         # but it is fine for result to have no columns at all if it is empty
-        if not (len(result.columns) == len(return_type) or
-                len(result.columns) == 0 and result.empty):
+        if not (
+            len(result.columns) == len(return_type) or len(result.columns) == 0 and result.empty
+        ):
             raise RuntimeError(
                 "Number of columns of the returned pandas.DataFrame "
                 "doesn't match specified schema. "
@@ -193,8 +194,9 @@ def wrap_grouped_map_pandas_udf(f, return_type, argspec):
             )
         # the number of columns of result have to match the return type
         # but it is fine for result to have no columns at all if it is empty
-        if not (len(result.columns) == len(return_type) or
-                len(result.columns) == 0 and result.empty):
+        if not (
+            len(result.columns) == len(return_type) or len(result.columns) == 0 and result.empty
+        ):
             raise RuntimeError(
                 "Number of columns of the returned pandas.DataFrame "
                 "doesn't match specified schema. "


### PR DESCRIPTION
### What changes were proposed in this pull request?
Methods `wrap_cogrouped_map_pandas_udf` and `wrap_grouped_map_pandas_udf` in `python/pyspark/worker.py` do not need to reject `pd.DataFrame`s with no columns return by udf when that DataFrame is empty (zero rows). This allows to return empty DataFrames without the need to define columns. The DataFrame is empty after all!

### Why are the changes needed?
Returning an empty DataFrame from the lambda given to `applyInPandas` should be as easy as this:

```python
return pd.DataFrame([])
```

However, PySpark requires that empty DataFrame to have the right _number_ of columns. This seems redundant as the schema is already defined in the `applyInPandas` call. Returning a non-empty DataFrame does not require defining columns.

Here is an example to reproduce:
```python
import pandas as pd  

from pyspark.sql.functions import pandas_udf, ceil

df = spark.createDataFrame(
    [(1, 1.0), (1, 2.0), (2, 3.0), (2, 5.0), (2, 10.0)],
    ("id", "v"))  

def mean_func(key, pdf):
    if key == (1,):
        return pd.DataFrame([])
    else:
        return pd.DataFrame([key + (pdf.v.mean(),)])

df.groupby("id").applyInPandas(mean_func, schema="id long, v double").show()
```

### Does this PR introduce _any_ user-facing change?
It changes the behaviour of the following calls to allow returning empty `pd.DataFrame` without defining columns. The PySpark DataFrame returned by `applyInPandas` is unchanged:

- `df.groupby(…).applyInPandas(…)`
- `df.cogroup(…).applyInPandas(…)`

### How was this patch tested?
Tests are added that test `applyInPandas` returning

- empty DataFrame with no columns
- empty DataFrame with the wrong number of columns
- non-empty DataFrame with wrong number of columns
- something other than `pd.DataFrame`

TODO:
- test cogroup
- check mapInPandas
- look for other methods returning pd.DataFrames