### PR TITLE
Get demo working

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -301,7 +301,7 @@ private[spark] class SparkSubmit extends Logging {
       printMessage(s"Armada selected as cluster manager.")
       if (!Utils.classIsLoadable(ARMADA_CLUSTER_SUBMIT_CLASS) && !Utils.isTesting) {
         error(
-          s"Could not load ARMADA class \"$ARMADA_CLUSTER_SUBMIT_CLASS\". " +
+          s"Could not load ARMADA class \"${ARMADA_CLUSTER_SUBMIT_CLASS}\". " +
           "This copy of Spark may not have been compiled with ARMADA support.")
       }
     }

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -301,7 +301,7 @@ private[spark] class SparkSubmit extends Logging {
       printMessage(s"Armada selected as cluster manager.")
       if (!Utils.classIsLoadable(ARMADA_CLUSTER_SUBMIT_CLASS) && !Utils.isTesting) {
         error(
-          s"Could not load ARMADA class \"${ARMADA_CLUSTER_SUBMIT_CLASS}\". " +
+          s"Could not load ARMADA class \"$ARMADA_CLUSTER_SUBMIT_CLASS\". " +
           "This copy of Spark may not have been compiled with ARMADA support.")
       }
     }
@@ -706,7 +706,7 @@ private[spark] class SparkSubmit extends Logging {
         mergeFn = Some(mergeFileLists(_, _))),
 
       // Other options
-      OptionAssigner(args.numExecutors, YARN | KUBERNETES, ALL_DEPLOY_MODES,
+      OptionAssigner(args.numExecutors, YARN | KUBERNETES | ARMADA, ALL_DEPLOY_MODES,
         confKey = EXECUTOR_INSTANCES.key),
       OptionAssigner(args.executorCores, STANDALONE | YARN | KUBERNETES, ALL_DEPLOY_MODES,
         confKey = EXECUTOR_CORES.key),

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -339,8 +339,8 @@ private[spark] class SparkSubmit extends Logging {
     val isKubernetesClient = clusterManager == KUBERNETES && deployMode == CLIENT
     val isKubernetesClusterModeDriver = isKubernetesClient &&
       sparkConf.getBoolean("spark.kubernetes.submitInDriver", false)
-    // TODO: does client/cluster mode matter here?
-    val isArmada = clusterManager == ARMADA
+    val isArmadaCluster = clusterManager == ARMADA && deployMode == CLUSTER
+    // TODO: Support armada & client?
     val isCustomClasspathInClusterModeDisallowed =
       !sparkConf.get(ALLOW_CUSTOM_CLASSPATH_BY_PROXY_USER_IN_CLUSTER_MODE) &&
       args.proxyUser != null &&
@@ -878,10 +878,9 @@ private[spark] class SparkSubmit extends Logging {
       }
     }
 
-    if (isArmada) {
-      // FIXME: Make sure we populate what we need here!
+    if (isArmadaCluster) {
       childMainClass = ARMADA_CLUSTER_SUBMIT_CLASS
-      childArgs ++= Array("--class", args.mainClass)
+      // TODO: Setup childArgs
     }
 
     // Load any properties specified through --conf and the default properties file

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -880,7 +880,26 @@ private[spark] class SparkSubmit extends Logging {
 
     if (isArmadaCluster) {
       childMainClass = ARMADA_CLUSTER_SUBMIT_CLASS
-      childArgs ++= Array("--main-class", args.mainClass)
+      if (args.primaryResource != SparkLauncher.NO_RESOURCE) {
+        if (args.isPython) {
+          childArgs ++= Array("--primary-py-file", args.primaryResource)
+          childArgs ++= Array("--main-class", "org.apache.spark.deploy.PythonRunner")
+        } else if (args.isR) {
+          childArgs ++= Array("--primary-r-file", args.primaryResource)
+          childArgs ++= Array("--main-class", "org.apache.spark.deploy.RRunner")
+        }
+        else {
+          childArgs ++= Array("--primary-java-resource", args.primaryResource)
+          childArgs ++= Array("--main-class", args.mainClass)
+        }
+      } else {
+        childArgs ++= Array("--main-class", args.mainClass)
+      }
+      if (args.childArgs != null) {
+        args.childArgs.foreach { arg =>
+          childArgs += "--arg" += arg
+        }
+      }
     }
 
     // Load any properties specified through --conf and the default properties file

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -880,7 +880,7 @@ private[spark] class SparkSubmit extends Logging {
 
     if (isArmadaCluster) {
       childMainClass = ARMADA_CLUSTER_SUBMIT_CLASS
-      // TODO: Setup childArgs
+      childArgs ++= Array("--main-class", args.mainClass)
     }
 
     // Load any properties specified through --conf and the default properties file

--- a/examples/submitSparkPi.sh
+++ b/examples/submitSparkPi.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# run spark pi app on armada
+bin/spark-submit --master armada://localhost:30002 --deploy-mode cluster --name spark-pi --class org.apache.spark.examples.SparkPi --conf spark.executor.instances=2 --conf spark.kubernetes.container.image=spark:testing local:///opt/spark/examples/jars/spark-examples.jar 100

--- a/resource-managers/armada/core/src/main/scala/io/armadaproject/spark/deploy/armada/ArmadaClientApplication.scala
+++ b/resource-managers/armada/core/src/main/scala/io/armadaproject/spark/deploy/armada/ArmadaClientApplication.scala
@@ -330,7 +330,7 @@ private[spark] class ArmadaClientApplication extends SparkApplication {
           "--conf",
           "spark.driver.port=7078",
           "--conf",
-          s"spark.driver.extraJavaOptions=$javaOptions",
+          s"spark.driver.extraJavaOptions=$javaOptions"
 
         ) ++ primaryResource ++ clientArguments.driverArgs
       )

--- a/resource-managers/armada/core/src/main/scala/io/armadaproject/spark/deploy/armada/ArmadaClientApplication.scala
+++ b/resource-managers/armada/core/src/main/scala/io/armadaproject/spark/deploy/armada/ArmadaClientApplication.scala
@@ -241,7 +241,7 @@ private[spark] class ArmadaClientApplication extends SparkApplication {
   }
 
   override def start(args: Array[String], conf: SparkConf): Unit = {
-    log("ArmadaClientApplication.start() called! arm5")
+    log("ArmadaClientApplication.start() called! arm6")
     val parsedArguments = ClientArguments.fromCommandLineArgs(args)
     run(parsedArguments, conf)
   }
@@ -304,7 +304,7 @@ private[spark] class ArmadaClientApplication extends SparkApplication {
     val envVars = Seq(
       new EnvVar().withName("SPARK_DRIVER_BIND_ADDRESS").withValueFrom(source)
     )
-    val javaOptions = "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=0.0.0.0:5005"
+    val javaOptions = "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0.0.0.0:5005"
     val driverContainer = Container()
       .withName("spark-driver")
       .withImagePullPolicy("IfNotPresent")
@@ -323,7 +323,8 @@ private[spark] class ArmadaClientApplication extends SparkApplication {
           "spark.driver.port=7078",
           "--conf",
           s"spark.driver.extraJavaOptions=$javaOptions",
-          "local:///opt/spark/examples/jars/spark-examples.jar"
+          "local:///opt/spark/examples/jars/spark-examples.jar",
+          "100"
         )
       )
       .withResources( // FIXME: What are reasonable requests/limits for spark drivers?

--- a/resource-managers/armada/core/src/main/scala/io/armadaproject/spark/deploy/armada/ArmadaClientApplication.scala
+++ b/resource-managers/armada/core/src/main/scala/io/armadaproject/spark/deploy/armada/ArmadaClientApplication.scala
@@ -361,9 +361,9 @@ private[spark] class ArmadaClientApplication extends SparkApplication {
     // FIXME: Plumb config for queue, job-set-id
     val jobSubmitResponse = armadaClient.SubmitJobs("test", "driver", Seq(driverJob))
 
-    log(s"Job Submit Response $jobSubmitResponse")
     for (respItem <- jobSubmitResponse.jobResponseItems) {
-      log(s"JobID: ${respItem.jobId}  Error: ${respItem.error} ")
+      val error = if (respItem.error == "") "None" else respItem.error
+      log(s"JobID: ${respItem.jobId}  Error: ${error}")
     }
     jobSubmitResponse.jobResponseItems.head.jobId
   }

--- a/resource-managers/armada/core/src/main/scala/io/armadaproject/spark/deploy/armada/ArmadaClientApplication.scala
+++ b/resource-managers/armada/core/src/main/scala/io/armadaproject/spark/deploy/armada/ArmadaClientApplication.scala
@@ -249,7 +249,7 @@ private[spark] class ArmadaClientApplication extends SparkApplication {
   private def run(clientArguments: ClientArguments, sparkConf: SparkConf): Unit = {
     val (host, port) = ArmadaUtils.parseMasterUrl(sparkConf.get("spark.master"))
     log(s"host is $host, port is $port")
-    var armadaClient = ArmadaClient(host, port)
+    val armadaClient = ArmadaClient(host, port)
     if (armadaClient.SubmitHealth().isServing) {
       log("Submit health good!")
     } else {
@@ -359,12 +359,12 @@ private[spark] class ArmadaClientApplication extends SparkApplication {
       .withPodSpec(podSpec)
 
     // FIXME: Plumb config for queue, job-set-id
-    val jobSubmitResponse = armadaClient.SubmitJobs("test", "spark-test-1", Seq(driverJob))
+    val jobSubmitResponse = armadaClient.SubmitJobs("test", "driver", Seq(driverJob))
 
     log(s"Job Submit Response $jobSubmitResponse")
     for (respItem <- jobSubmitResponse.jobResponseItems) {
       log(s"JobID: ${respItem.jobId}  Error: ${respItem.error} ")
     }
-    jobSubmitResponse.jobResponseItems(0).jobId
+    jobSubmitResponse.jobResponseItems.head.jobId
   }
 }

--- a/resource-managers/armada/core/src/main/scala/io/armadaproject/spark/deploy/armada/MainAppResource.scala
+++ b/resource-managers/armada/core/src/main/scala/io/armadaproject/spark/deploy/armada/MainAppResource.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.armada.submit
+
+
+import org.apache.spark.annotation.{DeveloperApi, Since, Stable}
+
+/**
+ * :: DeveloperApi ::
+ *
+ * All traits and classes in this file are used by K8s module and Spark K8s operator.
+ */
+
+@Stable
+@DeveloperApi
+@Since("2.3.0")
+sealed trait MainAppResource
+
+@Stable
+@DeveloperApi
+@Since("2.4.0")
+sealed trait NonJVMResource
+
+@Stable
+@DeveloperApi
+@Since("3.0.0")
+case class JavaMainAppResource(primaryResource: Option[String])
+  extends MainAppResource
+
+@Stable
+@DeveloperApi
+@Since("2.4.0")
+case class PythonMainAppResource(primaryResource: String)
+  extends MainAppResource with NonJVMResource
+
+@Stable
+@DeveloperApi
+@Since("2.4.0")
+case class RMainAppResource(primaryResource: String)
+  extends MainAppResource with NonJVMResource

--- a/resource-managers/armada/core/src/main/scala/io/armadaproject/spark/deploy/armada/MainAppResource.scala
+++ b/resource-managers/armada/core/src/main/scala/io/armadaproject/spark/deploy/armada/MainAppResource.scala
@@ -16,7 +16,6 @@
  */
 package org.apache.spark.deploy.armada.submit
 
-
 import org.apache.spark.annotation.{DeveloperApi, Since, Stable}
 
 /**

--- a/resource-managers/armada/core/src/main/scala/io/armadaproject/spark/scheduler/cluster/armada/ArmadaClusterManagerBackend.scala
+++ b/resource-managers/armada/core/src/main/scala/io/armadaproject/spark/scheduler/cluster/armada/ArmadaClusterManagerBackend.scala
@@ -29,6 +29,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.rpc.{RpcAddress, RpcCallContext}
 import org.apache.spark.scheduler.{ExecutorDecommission, TaskSchedulerImpl}
 import org.apache.spark.scheduler.cluster.{CoarseGrainedSchedulerBackend, SchedulerBackendUtils}
+import org.apache.spark.scheduler.cluster.SchedulerBackendUtils.getInitialTargetExecutorNumber
 
 
 // TODO: Implement for Armada
@@ -49,7 +50,7 @@ private[spark] class ArmadaClusterSchedulerBackend(
     }
 
 
-  private def submitJob(): Unit = {
+  private def submitJob(executorId: Int): Unit = {
 
     val urlArray = masterURL.split(":")
     // Remove leading "/"'s
@@ -63,7 +64,7 @@ private[spark] class ArmadaClusterSchedulerBackend(
     val source = EnvVarSource().withFieldRef(ObjectFieldSelector()
       .withApiVersion("v1").withFieldPath("status.podIP"))
     val envVars = Seq(
-      EnvVar().withName("SPARK_EXECUTOR_ID").withValue("1"),
+      EnvVar().withName("SPARK_EXECUTOR_ID").withValue(executorId.toString),
       EnvVar().withName("SPARK_RESOURCE_PROFILE_ID").withValue("0"),
       EnvVar().withName("SPARK_EXECUTOR_POD_NAME").withValue("test-pod-name"),
       EnvVar().withName("SPARK_APPLICATION_ID").withValue("test_spark_app_id"),
@@ -110,14 +111,15 @@ private[spark] class ArmadaClusterSchedulerBackend(
     val client = ArmadaClient(host, port)
     val jobSubmitResponse = client.SubmitJobs("test", "executor", Seq(testJob))
 
-    logInfo(s"Driver Job Submit Response")
+    logInfo(s"Driver Job Submit Response: arm10")
     for (respItem <- jobSubmitResponse.jobResponseItems) {
       logInfo(s"JobID: ${respItem.jobId}  Error: ${respItem.error} ")
 
     }
   }
     override def start(): Unit = {
-      submitJob()
+      val numberOfExecutors = getInitialTargetExecutorNumber(conf)
+      1 to numberOfExecutors foreach {j: Int => submitJob(j)}
     }
 
     override def stop(): Unit = {}
@@ -143,7 +145,7 @@ private[spark] class ArmadaClusterSchedulerBackend(
     }
 
     private class ArmadaDriverEndpoint extends DriverEndpoint {
-      protected val execIDRequester = new HashMap[RpcAddress, String]
+      private val execIDRequester = new HashMap[RpcAddress, String]
 
       override def receiveAndReply(context: RpcCallContext): PartialFunction[Any, Unit] =
             super.receiveAndReply(context)

--- a/resource-managers/armada/core/src/main/scala/io/armadaproject/spark/scheduler/cluster/armada/ArmadaClusterManagerBackend.scala
+++ b/resource-managers/armada/core/src/main/scala/io/armadaproject/spark/scheduler/cluster/armada/ArmadaClusterManagerBackend.scala
@@ -107,7 +107,7 @@ private[spark] class ArmadaClusterSchedulerBackend(
       .withNamespace("default")
       .withPodSpec(podSpec)
 
-    val client = new ArmadaClient(ArmadaClient.GetChannel(host, port))
+    val client = ArmadaClient(host, port)
     val jobSubmitResponse = client.SubmitJobs("test", "executor", Seq(testJob))
 
     logInfo(s"Driver Job Submit Response")


### PR DESCRIPTION
This PR allows you to do a spark submit of the spark pi app.  That creates a driver and 2 executors on armada.  Each executor does roughly half the work and returns the results to the driver.


You can see the result in the k8s logs, and the armada lookout ui shows all three jobs completing successfully.

To run it invoke:
```
examples/submitSparkPi.sh
```